### PR TITLE
supports parsing matroska MKV file and all track types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-.DS_Store
+# temporaries
+.*
 
+# binaries
+*.bin
+*.exe


### PR DESCRIPTION
Hi, @xlab 

This PR should be ok, it contains changes 
- supports parsing matroska/MKV container format file
- add all track types consts
- `SegmentInformation` add new func `GetDurationMs()` get duration in milliseconds

see also #1

